### PR TITLE
Add resize mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,34 @@
 # Getting Started
 
-	npm install evenizer -g
+```
+npm install evenizer -g
+```
 
 This module requires [ImageMagick](http://www.imagemagick.org/script/binary-releases.php)
 
 
 # Usage
 
-	evenizer -i path/to/png.png
+```
+evenizer -i path/to/png.png
+```
 
+## Options
+
+### Resize mode
+
+```
+evenizer --resize -i path/to/png.png
+```
 
 ## example
 
-	evenizer -i ./examples/149x39.png
-
+```
+evenizer -i ./examples/149x39.png
+```
 
 multiple png (use zsh)
 
-	evenizer -i ./path/to/**/*.png
-
+```
+evenizer -i ./path/to/**/*.png
+```

--- a/lib/evenizer.coffee
+++ b/lib/evenizer.coffee
@@ -15,8 +15,7 @@
 
 process.bin = process.title = 'evenizer'
 
-
-argv = require('optimist').argv
+argv = require('optimist').boolean('resize').argv
 if not argv.i
   console.log 'file not found'
   return
@@ -52,10 +51,17 @@ evenize = (fileName)=>
     #-background #e2ddd4 -gravity southeast -splice 1999x25 sample367e.png
 
     if south or east
-      im.convert([fileName, '-background', 'rgba(0, 0, 0, 0)','-gravity', direction, '-splice',  "#{east}x#{south}", fileName], (err, stdout) ->
-        throw err  if err
-        console.log "complete:", fileName
-      )
+      if argv.resize
+        im.convert([fileName, '-resize', "#{features.width + east}x#{features.height + south}\!", fileName], (err, stdout) ->
+          throw err  if err
+          console.log "complete:", fileName
+        )
+      else
+        im.convert([fileName, '-background', 'rgba(0, 0, 0, 0)','-gravity', direction, '-splice',  "#{east}x#{south}", fileName], (err, stdout) ->
+          throw err  if err
+          console.log "complete:", fileName
+        )
+
 
 doEvenize = =>
   for fileName in fileList

--- a/lib/evenizer.js
+++ b/lib/evenizer.js
@@ -13,7 +13,7 @@ var argv, doEvenize, evenize, exports, fileList, im;
 
 process.bin = process.title = 'evenizer';
 
-argv = require('optimist').argv;
+argv = require('optimist').boolean('resize').argv;
 
 if (!argv.i) {
   console.log('file not found');
@@ -56,12 +56,21 @@ evenize = (function(_this) {
       }
       direction = "" + direction1 + direction2;
       if (south || east) {
-        return im.convert([fileName, '-background', 'rgba(0, 0, 0, 0)', '-gravity', direction, '-splice', "" + east + "x" + south, fileName], function(err, stdout) {
-          if (err) {
-            throw err;
-          }
-          return console.log("complete:", fileName);
-        });
+        if (argv.resize) {
+          return im.convert([fileName, '-resize', "" + (features.width + east) + "x" + (features.height + south) + "\!", fileName], function(err, stdout) {
+            if (err) {
+              throw err;
+            }
+            return console.log("complete:", fileName);
+          });
+        } else {
+          return im.convert([fileName, '-background', 'rgba(0, 0, 0, 0)', '-gravity', direction, '-splice', "" + east + "x" + south, fileName], function(err, stdout) {
+            if (err) {
+              throw err;
+            }
+            return console.log("complete:", fileName);
+          });
+        }
       }
     });
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evenizer",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "odd pixel images convert to even pixel",
 
   "license": "MIT",


### PR DESCRIPTION
In some situation, the original mode (Add transparent background) is not suitable my need. For example, I need to add the border/box-shadow (CSS) to the image, but the transparent background will make a transparent line between them.

Sometimes I just need the image can resize in even dimensions, so I add a "resize" mode.

Please review my pull request, thank you.
And thank you for this useful & awesome project!
